### PR TITLE
[openssl] Update to 1.1.1l. Fixes JB#55284

### DIFF
--- a/rpm/openssl-1.1.1-version-override.patch
+++ b/rpm/openssl-1.1.1-version-override.patch
@@ -1,12 +1,13 @@
-diff -up openssl-1.1.1i/include/openssl/opensslv.h.version-override openssl-1.1.1i/include/openssl/opensslv.h
---- openssl-1.1.1i/include/openssl/opensslv.h.version-override	2020-12-09 10:25:12.042374409 +0100
-+++ openssl-1.1.1i/include/openssl/opensslv.h	2020-12-09 10:26:00.362769170 +0100
+diff --git a/include/openssl/opensslv.h b/include/openssl/opensslv.h
+index cbbfab12b3..8fda6b1b85 100644
+--- a/include/openssl/opensslv.h
++++ b/include/openssl/opensslv.h
 @@ -40,7 +40,7 @@ extern "C" {
   *  major minor fix final patch/beta)
   */
- # define OPENSSL_VERSION_NUMBER  0x101010bfL
--# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1k  25 Mar 2021"
-+# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1k  FIPS 25 Mar 2021"
+ # define OPENSSL_VERSION_NUMBER  0x101010cfL
+-# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1l  24 Aug 2021"
++# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1l  FIPS 24 Aug 2021"
  
  /*-
   * The macros below are to be used for shared library (.so, .dll, ...)

--- a/rpm/openssl.spec
+++ b/rpm/openssl.spec
@@ -26,7 +26,7 @@
 %define thread_test_threads %{?threads:%{threads}}%{!?threads:1}
 Summary: Utilities from the general purpose cryptography library with TLS implementation
 Name: openssl
-Version: 1.1.1k
+Version: 1.1.1l
 # Do not forget to bump SHLIB_VERSION on version upgrades
 Release: 1
 


### PR DESCRIPTION
This version fixes the following CVE's[1][[2]:
- Fixed an SM2 Decryption Buffer Overflow (CVE-2021-3711)
- Fixed various read buffer overruns processing ASN.1
  strings (CVE-2021-3712)

---
[1] https://www.openssl.org/news/changelog.html#openssl-111
[2] https://www.openssl.org/news/openssl-1.1.1-notes.html

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>