### PR TITLE
Fix building on SFDK

### DIFF
--- a/rpm/openssl.changes
+++ b/rpm/openssl.changes
@@ -68,7 +68,7 @@
   CVE-2014-0198,CVE-2010-5298,CVE-2014-3470]
   https://www.openssl.org/news/secadv_20140605.txt
 
-* Thu Apr 08 2014 Islam Amer <islam.amer@jollamobile.com> - 1.0.1g
+* Tue Apr 08 2014 Islam Amer <islam.amer@jollamobile.com> - 1.0.1g
 - Update to version 1.0.1g [CVE-2014-0160]
 
 * Sun Mar 09 2014 Islam Amer <islam.amer@jollamobile.com> - 1.0.1f
@@ -410,7 +410,7 @@
 * Tue Mar 16 2004 Phil Knirsch <pknirsch@redhat.com>
 - Fixed libica filespec.
 
-* Thu Mar 10 2004 Nalin Dahyabhai <nalin@redhat.com> 0.9.7a-34
+* Wed Mar 10 2004 Nalin Dahyabhai <nalin@redhat.com> 0.9.7a-34
 - ppc/ppc64 define __powerpc__/__powerpc64__, not __ppc__/__ppc64__, fix
   the intermediate header
 
@@ -502,7 +502,7 @@
 * Tue Jul 15 2003 Nalin Dahyabhai <nalin@redhat.com> 0.9.7a-10.9
 - free the kssl_ctx structure when we free an SSL structure (#99066)
 
-* Fri Jul 10 2003 Nalin Dahyabhai <nalin@redhat.com> 0.9.7a-16
+* Thu Jul 10 2003 Nalin Dahyabhai <nalin@redhat.com> 0.9.7a-16
 - rebuild
 
 * Thu Jul 10 2003 Nalin Dahyabhai <nalin@redhat.com> 0.9.7a-15
@@ -753,7 +753,7 @@
 - adjust the hobble script to not disturb symlinks in include/ (fix from
   Joe Orton)
 
-* Fri Apr 26 2001 Nalin Dahyabhai <nalin@redhat.com>
+* Thu Apr 26 2001 Nalin Dahyabhai <nalin@redhat.com>
 - drop the m2crypo patch we weren't using
 
 * Tue Apr 24 2001 Nalin Dahyabhai <nalin@redhat.com>

--- a/rpm/openssl.spec
+++ b/rpm/openssl.spec
@@ -320,7 +320,7 @@ install -m755 %{SOURCE7} $RPM_BUILD_ROOT%{_bindir}/renew-dummy-cert
 # docs are disabled
 # BEGIN
 # Rename man pages so that they don't conflict with other system man pages.
-#pushd $RPM_BUILD_ROOT%{_mandir}
+#pushd $RPM_BUILD_ROOT %%{_mandir}
 #ln -s -f config.5 man5/openssl.cnf.5
 #for manpage in man*/* ; do
 #	if [ -L ${manpage} ]; then
@@ -409,14 +409,14 @@ cp -a /%{_lib}/libcrypto.so.%{old_soversion} $RPM_BUILD_ROOT/%{_lib}/.
 %attr(0755,root,root) %{_bindir}/openssl
 # docs are disabled
 # BEGIN
-#%{_mandir}/man1*/*
-#%{_mandir}/man5*/*
-#%{_mandir}/man7*/*
-#%{_docdir}/Makefile.certificate
-#%exclude %{_mandir}/man1*/*.pl*
-#%exclude %{_mandir}/man1*/c_rehash*
-#%exclude %{_mandir}/man1*/tsget*
-#%exclude %{_mandir}/man1*/openssl-tsget*
+#%%{_mandir}/man1*/*
+#%%{_mandir}/man5*/*
+#%%{_mandir}/man7*/*
+#%%{_docdir}/Makefile.certificate
+#%exclude %%{_mandir}/man1*/*.pl*
+#%exclude %%{_mandir}/man1*/c_rehash*
+#%exclude %%{_mandir}/man1*/tsget*
+#%exclude %%{_mandir}/man1*/openssl-tsget*
 # END
 %files libs
 %defattr(-,root,root)
@@ -441,8 +441,8 @@ cp -a /%{_lib}/libcrypto.so.%{old_soversion} $RPM_BUILD_ROOT/%{_lib}/.
 /%{_lib}/libcrypto.so.%{old_soversion}
 %endif
 
-#%attr(0644,root,root) %{_libdir}/.libcrypto.so.*.hmac
-#%attr(0644,root,root) %{_libdir}/.libssl.so.*.hmac
+#%attr(0644,root,root) %%{_libdir}/.libcrypto.so.*.hmac
+#%attr(0644,root,root) %%{_libdir}/.libssl.so.*.hmac
 %attr(0755,root,root) %{_libdir}/%{name}
 
 %files devel
@@ -450,7 +450,7 @@ cp -a /%{_lib}/libcrypto.so.%{old_soversion} $RPM_BUILD_ROOT/%{_lib}/.
 %doc CHANGES doc/dir-locals.example.el doc/openssl-c-indent.el
 %{_prefix}/include/openssl
 %attr(0755,root,root) %{_libdir}/*.so
-#%{_mandir}/man3*/*  docs are disabled
+#%%{_mandir}/man3*/*  docs are disabled
 %attr(0644,root,root) %{_libdir}/pkgconfig/*.pc
 
 %files static
@@ -463,10 +463,10 @@ cp -a /%{_lib}/libcrypto.so.%{old_soversion} $RPM_BUILD_ROOT/%{_lib}/.
 %{_sysconfdir}/pki/tls/misc/tsget
 # docs are disabled
 # BEGIN
-#%{_mandir}/man1*/*.pl*
-#%{_mandir}/man1*/c_rehash*
-#%{_mandir}/man1*/tsget*
-#%{_mandir}/man1*/openssl-tsget*
+#%%{_mandir}/man1*/*.pl*
+#%%{_mandir}/man1*/c_rehash*
+#%%{_mandir}/man1*/tsget*
+#%%{_mandir}/man1*/openssl-tsget*
 # END
 %dir %{_sysconfdir}/pki/CA
 %dir %{_sysconfdir}/pki/CA/private


### PR DESCRIPTION
This is a cosmetic PR to make the `.spec` and `.changes` files pass the parsers.

With these changes I'm able to successfully build OpenSSL for 4.3.0.12-armv7hl and 4.5.0.18-armv7hl targets on SFDK version 3.10.4 w/Docker using `sfdk build`.