### PR TITLE
[openssl] Update to 1.1.1v. Fixes JB#61009

### DIFF
--- a/rpm/openssl-1.1.1-alpn-cb.patch
+++ b/rpm/openssl-1.1.1-alpn-cb.patch
@@ -16,7 +16,7 @@ diff --git a/apps/s_server.c b/apps/s_server.c
 index bcc83e562c..591c6c19c5 100644
 --- a/apps/s_server.c
 +++ b/apps/s_server.c
-@@ -707,7 +707,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
+@@ -716,7 +716,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
      if (SSL_select_next_proto
          ((unsigned char **)out, outlen, alpn_ctx->data, alpn_ctx->len, in,
           inlen) != OPENSSL_NPN_NEGOTIATED) {

--- a/rpm/openssl-1.1.1-build.patch
+++ b/rpm/openssl-1.1.1-build.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1f/Configurations/10-main.conf.build openssl-1.1.1f/Configurations/10-main.conf
 --- openssl-1.1.1f/Configurations/10-main.conf.build	2020-03-31 14:17:45.000000000 +0200
 +++ openssl-1.1.1f/Configurations/10-main.conf	2020-04-07 16:42:10.920546387 +0200
-@@ -678,6 +678,7 @@ my %targets = (
+@@ -679,6 +679,7 @@ my %targets = (
          cxxflags         => add("-m64"),
          lib_cppflags     => add("-DL_ENDIAN"),
          perlasm_scheme   => "linux64le",
@@ -9,7 +9,7 @@ diff -up openssl-1.1.1f/Configurations/10-main.conf.build openssl-1.1.1f/Configu
      },
  
      "linux-armv4" => {
-@@ -718,6 +719,7 @@ my %targets = (
+@@ -719,6 +720,7 @@ my %targets = (
      "linux-aarch64" => {
          inherit_from     => [ "linux-generic64", asm("aarch64_asm") ],
          perlasm_scheme   => "linux64",
@@ -20,7 +20,7 @@ diff -up openssl-1.1.1f/Configurations/10-main.conf.build openssl-1.1.1f/Configu
 diff -up openssl-1.1.1f/Configurations/unix-Makefile.tmpl.build openssl-1.1.1f/Configurations/unix-Makefile.tmpl
 --- openssl-1.1.1f/Configurations/unix-Makefile.tmpl.build	2020-04-07 16:42:10.920546387 +0200
 +++ openssl-1.1.1f/Configurations/unix-Makefile.tmpl	2020-04-07 16:44:23.539142108 +0200
-@@ -823,7 +823,7 @@ uninstall_runtime_libs:
+@@ -822,7 +822,7 @@ uninstall_runtime_libs:
  install_man_docs:
  	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
  	@$(ECHO) "*** Installing manpages"
@@ -29,7 +29,7 @@ diff -up openssl-1.1.1f/Configurations/unix-Makefile.tmpl.build openssl-1.1.1f/C
  		"--destdir=$(DESTDIR)$(MANDIR)" --type=man --suffix=$(MANSUFFIX)
  
  uninstall_man_docs:
-@@ -835,7 +835,7 @@ uninstall_man_docs:
+@@ -834,7 +834,7 @@ uninstall_man_docs:
  install_html_docs:
  	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
  	@$(ECHO) "*** Installing HTML manpages"

--- a/rpm/openssl-1.1.1-conf-paths.patch
+++ b/rpm/openssl-1.1.1-conf-paths.patch
@@ -13,7 +13,7 @@ diff -up openssl-1.1.1-pre8/apps/CA.pl.in.conf-paths openssl-1.1.1-pre8/apps/CA.
 diff -up openssl-1.1.1-pre8/apps/openssl.cnf.conf-paths openssl-1.1.1-pre8/apps/openssl.cnf
 --- openssl-1.1.1-pre8/apps/openssl.cnf.conf-paths	2018-07-25 17:26:58.378624057 +0200
 +++ openssl-1.1.1-pre8/apps/openssl.cnf	2018-07-27 13:20:08.198513471 +0200
-@@ -23,6 +23,22 @@ oid_section		= new_oids
+@@ -22,6 +22,22 @@ oid_section		= new_oids
  # (Alternatively, use a configuration file that has only
  # X.509v3 extensions in its main [= default] section.)
  
@@ -36,7 +36,7 @@ diff -up openssl-1.1.1-pre8/apps/openssl.cnf.conf-paths openssl-1.1.1-pre8/apps/
  [ new_oids ]
  
  # We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
-@@ -43,7 +59,7 @@ default_ca	= CA_default		# The default c
+@@ -42,7 +58,7 @@ default_ca	= CA_default		# The default c
  ####################################################################
  [ CA_default ]
  
@@ -45,7 +45,7 @@ diff -up openssl-1.1.1-pre8/apps/openssl.cnf.conf-paths openssl-1.1.1-pre8/apps/
  certs		= $dir/certs		# Where the issued certs are kept
  crl_dir		= $dir/crl		# Where the issued crl are kept
  database	= $dir/index.txt	# database index file.
-@@ -329,7 +345,7 @@ default_tsa = tsa_config1	# the default
+@@ -327,7 +343,7 @@ default_tsa = tsa_config1	# the default
  [ tsa_config1 ]
  
  # These are used by the TSA reply generation only.

--- a/rpm/openssl-1.1.1-disable-ssl3.patch
+++ b/rpm/openssl-1.1.1-disable-ssl3.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1-pre8/apps/s_client.c.disable-ssl3 openssl-1.1.1-pre8/apps/s_client.c
 --- openssl-1.1.1-pre8/apps/s_client.c.disable-ssl3	2018-07-16 18:08:20.000487628 +0200
 +++ openssl-1.1.1-pre8/apps/s_client.c	2018-07-16 18:16:40.070186323 +0200
-@@ -1681,6 +1681,9 @@ int s_client_main(int argc, char **argv)
+@@ -1737,6 +1737,9 @@ int s_client_main(int argc, char **argv)
      if (sdebug)
          ssl_ctx_security_debug(ctx, sdebug);
  
@@ -14,7 +14,7 @@ diff -up openssl-1.1.1-pre8/apps/s_client.c.disable-ssl3 openssl-1.1.1-pre8/apps
 diff -up openssl-1.1.1-pre8/apps/s_server.c.disable-ssl3 openssl-1.1.1-pre8/apps/s_server.c
 --- openssl-1.1.1-pre8/apps/s_server.c.disable-ssl3	2018-07-16 18:08:20.000487628 +0200
 +++ openssl-1.1.1-pre8/apps/s_server.c	2018-07-16 18:17:17.300055551 +0200
-@@ -1760,6 +1760,9 @@ int s_server_main(int argc, char *argv[]
+@@ -1798,6 +1798,9 @@ int s_server_main(int argc, char *argv[]
      if (sdebug)
          ssl_ctx_security_debug(ctx, sdebug);
  
@@ -27,7 +27,7 @@ diff -up openssl-1.1.1-pre8/apps/s_server.c.disable-ssl3 openssl-1.1.1-pre8/apps
 diff -up openssl-1.1.1-pre8/ssl/ssl_lib.c.disable-ssl3 openssl-1.1.1-pre8/ssl/ssl_lib.c
 --- openssl-1.1.1-pre8/ssl/ssl_lib.c.disable-ssl3	2018-06-20 16:48:13.000000000 +0200
 +++ openssl-1.1.1-pre8/ssl/ssl_lib.c	2018-07-16 18:08:20.001487652 +0200
-@@ -3016,6 +3016,16 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
+@@ -3174,6 +3174,16 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
       */
      ret->options |= SSL_OP_NO_COMPRESSION | SSL_OP_ENABLE_MIDDLEBOX_COMPAT;
  
@@ -77,7 +77,7 @@ diff -up openssl-1.1.1-pre8/test/ssl_test.c.disable-ssl3 openssl-1.1.1-pre8/test
 diff -up openssl-1.1.1-pre8/test/ssltest_old.c.disable-ssl3 openssl-1.1.1-pre8/test/ssltest_old.c
 --- openssl-1.1.1-pre8/test/ssltest_old.c.disable-ssl3	2018-06-20 16:48:15.000000000 +0200
 +++ openssl-1.1.1-pre8/test/ssltest_old.c	2018-07-16 18:08:20.002487676 +0200
-@@ -1358,6 +1358,11 @@ int main(int argc, char *argv[])
+@@ -1397,6 +1397,11 @@ int main(int argc, char *argv[])
          ERR_print_errors(bio_err);
          goto end;
      }

--- a/rpm/openssl-1.1.1-ec-curves.patch
+++ b/rpm/openssl-1.1.1-ec-curves.patch
@@ -124,7 +124,7 @@ diff -up openssl-1.1.1h/apps/speed.c.curves openssl-1.1.1h/apps/speed.c
          /* Other and ECDH only ones */
          {"X25519", NID_X25519, 253},
          {"X448", NID_X448, 448}
-@@ -2026,9 +1945,9 @@ int speed_main(int argc, char **argv)
+@@ -2030,9 +1949,9 @@ int speed_main(int argc, char **argv)
  #  endif
  
  #  ifndef OPENSSL_NO_EC
@@ -137,7 +137,7 @@ diff -up openssl-1.1.1h/apps/speed.c.curves openssl-1.1.1h/apps/speed.c
          ecdsa_c[i][0] = ecdsa_c[i - 1][0] / 2;
          ecdsa_c[i][1] = ecdsa_c[i - 1][1] / 2;
          if (ecdsa_doit[i] <= 1 && ecdsa_c[i][0] == 0)
-@@ -2040,7 +1959,7 @@ int speed_main(int argc, char **argv)
+@@ -2044,7 +1963,7 @@ int speed_main(int argc, char **argv)
              }
          }
      }
@@ -146,7 +146,7 @@ diff -up openssl-1.1.1h/apps/speed.c.curves openssl-1.1.1h/apps/speed.c
      ecdsa_c[R_EC_K163][0] = count / 1000;
      ecdsa_c[R_EC_K163][1] = count / 1000 / 2;
      for (i = R_EC_K233; i <= R_EC_K571; i++) {
-@@ -2071,8 +1990,8 @@ int speed_main(int argc, char **argv)
+@@ -2075,8 +1994,8 @@ int speed_main(int argc, char **argv)
      }
  #   endif
  
@@ -157,7 +157,7 @@ diff -up openssl-1.1.1h/apps/speed.c.curves openssl-1.1.1h/apps/speed.c
          ecdh_c[i][0] = ecdh_c[i - 1][0] / 2;
          if (ecdh_doit[i] <= 1 && ecdh_c[i][0] == 0)
              ecdh_doit[i] = 0;
-@@ -2082,7 +2001,7 @@ int speed_main(int argc, char **argv)
+@@ -2086,7 +2005,7 @@ int speed_main(int argc, char **argv)
              }
          }
      }

--- a/rpm/openssl-1.1.1-evp-kdf.patch
+++ b/rpm/openssl-1.1.1-evp-kdf.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1j/crypto/err/openssl.txt.evp-kdf openssl-1.1.1j/crypto/err/openssl.txt
 --- openssl-1.1.1j/crypto/err/openssl.txt.evp-kdf	2021-02-16 16:24:01.000000000 +0100
 +++ openssl-1.1.1j/crypto/err/openssl.txt	2021-03-03 14:10:13.729466935 +0100
-@@ -748,6 +748,9 @@ EVP_F_EVP_DIGESTINIT_EX:128:EVP_DigestIn
+@@ -749,6 +749,9 @@ EVP_F_EVP_DIGESTINIT_EX:128:EVP_DigestIn
  EVP_F_EVP_ENCRYPTDECRYPTUPDATE:219:evp_EncryptDecryptUpdate
  EVP_F_EVP_ENCRYPTFINAL_EX:127:EVP_EncryptFinal_ex
  EVP_F_EVP_ENCRYPTUPDATE:167:EVP_EncryptUpdate
@@ -11,7 +11,7 @@ diff -up openssl-1.1.1j/crypto/err/openssl.txt.evp-kdf openssl-1.1.1j/crypto/err
  EVP_F_EVP_MD_CTX_COPY_EX:110:EVP_MD_CTX_copy_ex
  EVP_F_EVP_MD_SIZE:162:EVP_MD_size
  EVP_F_EVP_OPENINIT:102:EVP_OpenInit
-@@ -810,12 +813,31 @@ EVP_F_PKCS5_PBE_KEYIVGEN:117:PKCS5_PBE_k
+@@ -811,12 +814,31 @@ EVP_F_PKCS5_PBE_KEYIVGEN:117:PKCS5_PBE_k
  EVP_F_PKCS5_V2_PBE_KEYIVGEN:118:PKCS5_v2_PBE_keyivgen
  EVP_F_PKCS5_V2_PBKDF2_KEYIVGEN:164:PKCS5_v2_PBKDF2_keyivgen
  EVP_F_PKCS5_V2_SCRYPT_KEYIVGEN:180:PKCS5_v2_scrypt_keyivgen
@@ -43,7 +43,7 @@ diff -up openssl-1.1.1j/crypto/err/openssl.txt.evp-kdf openssl-1.1.1j/crypto/err
  KDF_F_PKEY_HKDF_CTRL_STR:103:pkey_hkdf_ctrl_str
  KDF_F_PKEY_HKDF_DERIVE:102:pkey_hkdf_derive
  KDF_F_PKEY_HKDF_INIT:108:pkey_hkdf_init
-@@ -827,6 +849,7 @@ KDF_F_PKEY_SCRYPT_SET_MEMBUF:107:pkey_sc
+@@ -828,6 +850,7 @@ KDF_F_PKEY_SCRYPT_SET_MEMBUF:107:pkey_sc
  KDF_F_PKEY_TLS1_PRF_CTRL_STR:100:pkey_tls1_prf_ctrl_str
  KDF_F_PKEY_TLS1_PRF_DERIVE:101:pkey_tls1_prf_derive
  KDF_F_PKEY_TLS1_PRF_INIT:110:pkey_tls1_prf_init
@@ -51,7 +51,7 @@ diff -up openssl-1.1.1j/crypto/err/openssl.txt.evp-kdf openssl-1.1.1j/crypto/err
  KDF_F_TLS1_PRF_ALG:111:tls1_prf_alg
  OBJ_F_OBJ_ADD_OBJECT:105:OBJ_add_object
  OBJ_F_OBJ_ADD_SIGID:107:OBJ_add_sigid
-@@ -2284,6 +2307,7 @@ EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_K
+@@ -2290,6 +2313,7 @@ EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_K
  	operation not supported for this keytype
  EVP_R_OPERATON_NOT_INITIALIZED:151:operaton not initialized
  EVP_R_OUTPUT_WOULD_OVERFLOW:184:output would overflow
@@ -59,7 +59,7 @@ diff -up openssl-1.1.1j/crypto/err/openssl.txt.evp-kdf openssl-1.1.1j/crypto/err
  EVP_R_PARTIALLY_OVERLAPPING:162:partially overlapping buffers
  EVP_R_PBKDF2_ERROR:181:pbkdf2 error
  EVP_R_PKEY_APPLICATION_ASN1_METHOD_ALREADY_REGISTERED:179:\
-@@ -2320,6 +2344,7 @@ KDF_R_MISSING_SEED:106:missing seed
+@@ -2326,6 +2350,7 @@ KDF_R_MISSING_SEED:106:missing seed
  KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
  KDF_R_VALUE_ERROR:108:value error
  KDF_R_VALUE_MISSING:102:value missing

--- a/rpm/openssl-1.1.1-fips-crng-test.patch
+++ b/rpm/openssl-1.1.1-fips-crng-test.patch
@@ -186,7 +186,7 @@ diff -up openssl-1.1.1g/crypto/rand/rand_local.h.crng-test openssl-1.1.1g/crypto
  
  /*
   * Maximum allocation size for RANDOM_POOL buffers
-@@ -296,4 +306,22 @@ int rand_drbg_enable_locking(RAND_DRBG *
+@@ -303,4 +313,22 @@ int rand_drbg_enable_locking(RAND_DRBG *
  /* initializes the AES-CTR DRBG implementation */
  int drbg_ctr_init(RAND_DRBG *drbg);
  
@@ -212,7 +212,7 @@ diff -up openssl-1.1.1g/crypto/rand/rand_local.h.crng-test openssl-1.1.1g/crypto
 diff -up openssl-1.1.1g/include/crypto/rand.h.crng-test openssl-1.1.1g/include/crypto/rand.h
 --- openssl-1.1.1g/include/crypto/rand.h.crng-test	2020-04-23 13:30:45.824390573 +0200
 +++ openssl-1.1.1g/include/crypto/rand.h	2020-04-23 13:30:45.864389819 +0200
-@@ -49,6 +49,14 @@ size_t rand_drbg_get_additional_data(RAN
+@@ -59,6 +59,14 @@ size_t rand_drbg_get_additional_data(RAN
  
  void rand_drbg_cleanup_additional_data(RAND_POOL *pool, unsigned char *out);
  
@@ -272,7 +272,7 @@ diff -up openssl-1.1.1g/test/drbgtest.c.crng-test openssl-1.1.1g/test/drbgtest.c
          failures++;
          goto err;
      }
-@@ -293,7 +319,8 @@ static int error_check(DRBG_SELFTEST_DAT
+@@ -292,7 +318,8 @@ static int error_check(DRBG_SELFTEST_DAT
      unsigned int reseed_counter_tmp;
      int ret = 0;
  
@@ -282,7 +282,7 @@ diff -up openssl-1.1.1g/test/drbgtest.c.crng-test openssl-1.1.1g/test/drbgtest.c
          goto err;
  
      /*
-@@ -740,6 +767,10 @@ static int test_rand_drbg_reseed(void)
+@@ -739,6 +766,10 @@ static int test_rand_drbg_reseed(void)
          || !TEST_ptr_eq(private->parent, master))
          return 0;
  
@@ -293,7 +293,7 @@ diff -up openssl-1.1.1g/test/drbgtest.c.crng-test openssl-1.1.1g/test/drbgtest.c
      /* uninstantiate the three global DRBGs */
      RAND_DRBG_uninstantiate(private);
      RAND_DRBG_uninstantiate(public);
-@@ -964,7 +995,8 @@ static int test_rand_seed(void)
+@@ -963,7 +994,8 @@ static int test_rand_seed(void)
      size_t rand_buflen;
      size_t required_seed_buflen = 0;
  
@@ -303,7 +303,7 @@ diff -up openssl-1.1.1g/test/drbgtest.c.crng-test openssl-1.1.1g/test/drbgtest.c
          return 0;
  
  #ifdef OPENSSL_RAND_SEED_NONE
-@@ -1013,6 +1045,95 @@ static int test_rand_add(void)
+@@ -1012,6 +1044,95 @@ static int test_rand_add(void)
      return 1;
  }
  
@@ -399,7 +399,7 @@ diff -up openssl-1.1.1g/test/drbgtest.c.crng-test openssl-1.1.1g/test/drbgtest.c
  int setup_tests(void)
  {
      app_data_index = RAND_DRBG_get_ex_new_index(0L, NULL, NULL, NULL, NULL);
-@@ -1025,5 +1146,6 @@ int setup_tests(void)
+@@ -1024,5 +1145,6 @@ int setup_tests(void)
  #if defined(OPENSSL_THREADS)
      ADD_TEST(test_multi_thread);
  #endif

--- a/rpm/openssl-1.1.1-fips-curves.patch
+++ b/rpm/openssl-1.1.1-fips-curves.patch
@@ -184,7 +184,7 @@ diff -up openssl-1.1.1g/ssl/t1_lib.c.fips-curves openssl-1.1.1g/ssl/t1_lib.c
          /* We never allow GOST sig algs on the server with TLSv1.3 */
          if (s->server && SSL_IS_TLS13(s))
              return 0;
-@@ -2842,6 +2882,13 @@ int tls_choose_sigalg(SSL *s, int fatale
+@@ -2881,6 +2921,13 @@ int tls_choose_sigalg(SSL *s, int fatale
                  const uint16_t *sent_sigs;
                  size_t sent_sigslen;
  

--- a/rpm/openssl-1.1.1-fips-dh.patch
+++ b/rpm/openssl-1.1.1-fips-dh.patch
@@ -1987,8 +1987,8 @@ diff -up openssl-1.1.1j/crypto/dh/dh_check.c.fips-dh openssl-1.1.1j/crypto/dh/dh
 +/* Note: according to documentation - this only checks the params */
  int DH_check(const DH *dh, int *ret)
  {
-     int ok = 0, r;
-@@ -104,6 +112,9 @@ int DH_check(const DH *dh, int *ret)
+     int ok = 0, r, q_good = 0;
+@@ -111,6 +119,9 @@ int DH_check(const DH *dh, int *ret)
      if (!DH_check_params(dh, ret))
          return 0;
  
@@ -1998,7 +1998,7 @@ diff -up openssl-1.1.1j/crypto/dh/dh_check.c.fips-dh openssl-1.1.1j/crypto/dh/dh
      ctx = BN_CTX_new();
      if (ctx == NULL)
          goto err;
-@@ -177,7 +188,7 @@ int DH_check_pub_key_ex(const DH *dh, co
+@@ -191,7 +202,7 @@ int DH_check_pub_key_ex(const DH *dh, co
      return errflags == 0;
  }
  
@@ -2007,7 +2007,7 @@ diff -up openssl-1.1.1j/crypto/dh/dh_check.c.fips-dh openssl-1.1.1j/crypto/dh/dh
  {
      int ok = 0;
      BIGNUM *tmp = NULL;
-@@ -198,9 +209,9 @@ int DH_check_pub_key(const DH *dh, const
+@@ -212,9 +223,9 @@ int DH_check_pub_key(const DH *dh, const
      if (BN_cmp(pub_key, tmp) >= 0)
          *ret |= DH_CHECK_PUBKEY_TOO_LARGE;
  
@@ -2019,7 +2019,7 @@ diff -up openssl-1.1.1j/crypto/dh/dh_check.c.fips-dh openssl-1.1.1j/crypto/dh/dh
              goto err;
          if (!BN_is_one(tmp))
              *ret |= DH_CHECK_PUBKEY_INVALID;
-@@ -212,3 +223,23 @@ int DH_check_pub_key(const DH *dh, const
+@@ -226,3 +237,23 @@ int DH_check_pub_key(const DH *dh, const
      BN_CTX_free(ctx);
      return ok;
  }
@@ -2438,7 +2438,7 @@ diff -up openssl-1.1.1j/crypto/ec/ec_key.c.fips-dh openssl-1.1.1j/crypto/ec/ec_k
 diff -up openssl-1.1.1j/crypto/evp/p_lib.c.fips-dh openssl-1.1.1j/crypto/evp/p_lib.c
 --- openssl-1.1.1j/crypto/evp/p_lib.c.fips-dh	2021-02-16 16:24:01.000000000 +0100
 +++ openssl-1.1.1j/crypto/evp/p_lib.c	2021-03-03 14:23:27.405092436 +0100
-@@ -540,7 +540,8 @@ EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *p
+@@ -545,7 +545,8 @@ EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *p
  
  int EVP_PKEY_set1_DH(EVP_PKEY *pkey, DH *key)
  {
@@ -2664,7 +2664,7 @@ diff -up openssl-1.1.1j/include/openssl/obj_mac.h.fips-dh openssl-1.1.1j/include
 diff -up openssl-1.1.1j/ssl/s3_lib.c.fips-dh openssl-1.1.1j/ssl/s3_lib.c
 --- openssl-1.1.1j/ssl/s3_lib.c.fips-dh	2021-03-03 14:23:27.354091997 +0100
 +++ openssl-1.1.1j/ssl/s3_lib.c	2021-03-03 14:23:27.407092453 +0100
-@@ -4849,13 +4849,51 @@ int ssl_derive(SSL *s, EVP_PKEY *privkey
+@@ -4864,13 +4864,51 @@ int ssl_derive(SSL *s, EVP_PKEY *privkey
  EVP_PKEY *ssl_dh_to_pkey(DH *dh)
  {
      EVP_PKEY *ret;
@@ -2719,7 +2719,7 @@ diff -up openssl-1.1.1j/ssl/s3_lib.c.fips-dh openssl-1.1.1j/ssl/s3_lib.c
 diff -up openssl-1.1.1j/ssl/t1_lib.c.fips-dh openssl-1.1.1j/ssl/t1_lib.c
 --- openssl-1.1.1j/ssl/t1_lib.c.fips-dh	2021-03-03 14:23:27.401092401 +0100
 +++ openssl-1.1.1j/ssl/t1_lib.c	2021-03-03 14:23:27.407092453 +0100
-@@ -2542,7 +2542,7 @@ DH *ssl_get_auto_dh(SSL *s)
+@@ -2547,7 +2547,7 @@ DH *ssl_get_auto_dh(SSL *s)
          p = BN_get_rfc3526_prime_4096(NULL);
      else if (dh_secbits >= 128)
          p = BN_get_rfc3526_prime_3072(NULL);

--- a/rpm/openssl-1.1.1-fips-drbg-selftest.patch
+++ b/rpm/openssl-1.1.1-fips-drbg-selftest.patch
@@ -575,7 +575,7 @@ diff -up openssl-1.1.1g/crypto/rand/drbg_selftest.c.drbg-selftest openssl-1.1.1g
 diff -up openssl-1.1.1g/include/crypto/rand.h.drbg-selftest openssl-1.1.1g/include/crypto/rand.h
 --- openssl-1.1.1g/include/crypto/rand.h.drbg-selftest	2020-04-23 13:33:12.587622510 +0200
 +++ openssl-1.1.1g/include/crypto/rand.h	2020-04-23 13:33:12.619621907 +0200
-@@ -140,4 +140,9 @@ void rand_pool_cleanup(void);
+@@ -150,4 +150,9 @@ void rand_pool_cleanup(void);
   */
  void rand_pool_keep_random_devices_open(int keep);
  

--- a/rpm/openssl-1.1.1-fips-post-rand.patch
+++ b/rpm/openssl-1.1.1-fips-post-rand.patch
@@ -54,7 +54,7 @@ diff -up openssl-1.1.1i/crypto/fips/fips.c.fips-post-rand openssl-1.1.1i/crypto/
 diff -up openssl-1.1.1i/crypto/rand/drbg_lib.c.fips-post-rand openssl-1.1.1i/crypto/rand/drbg_lib.c
 --- openssl-1.1.1i/crypto/rand/drbg_lib.c.fips-post-rand	2020-12-08 14:20:59.000000000 +0100
 +++ openssl-1.1.1i/crypto/rand/drbg_lib.c	2020-12-09 10:26:41.652106475 +0100
-@@ -1005,6 +1005,20 @@ size_t rand_drbg_seedlen(RAND_DRBG *drbg
+@@ -995,6 +995,20 @@ size_t rand_drbg_seedlen(RAND_DRBG *drbg
      return min_entropy > min_entropylen ? min_entropy : min_entropylen;
  }
  
@@ -108,7 +108,7 @@ diff -up openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1i/cr
  #  if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__) && !defined(__hpux)
      extern int getentropy(void *buffer, size_t length) __attribute__((weak));
  
-@@ -394,10 +397,10 @@ static ssize_t syscall_random(void *buf,
+@@ -399,10 +402,10 @@ static ssize_t syscall_random(void *buf,
      if (p_getentropy.p != NULL)
          return p_getentropy.f(buf, buflen) == 0 ? (ssize_t)buflen : -1;
  #  endif
@@ -122,7 +122,7 @@ diff -up openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1i/cr
  #  elif (defined(__FreeBSD__) || defined(__NetBSD__)) && defined(KERN_ARND)
      return sysctl_random(buf, buflen);
  #  else
-@@ -633,6 +636,9 @@ size_t rand_pool_acquire_entropy(RAND_PO
+@@ -638,6 +641,9 @@ size_t rand_pool_acquire_entropy(RAND_PO
      size_t entropy_available;
  
  #   if defined(OPENSSL_RAND_SEED_GETRANDOM)
@@ -132,7 +132,7 @@ diff -up openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1i/cr
      {
          size_t bytes_needed;
          unsigned char *buffer;
-@@ -643,7 +649,7 @@ size_t rand_pool_acquire_entropy(RAND_PO
+@@ -648,7 +654,7 @@ size_t rand_pool_acquire_entropy(RAND_PO
          bytes_needed = rand_pool_bytes_needed(pool, 1 /*entropy_factor*/);
          while (bytes_needed != 0 && attempts-- > 0) {
              buffer = rand_pool_add_begin(pool, bytes_needed);
@@ -141,7 +141,7 @@ diff -up openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1i/cr
              if (bytes > 0) {
                  rand_pool_add_end(pool, bytes, 8 * bytes);
                  bytes_needed -= bytes;
-@@ -678,8 +684,10 @@ size_t rand_pool_acquire_entropy(RAND_PO
+@@ -683,8 +689,10 @@ size_t rand_pool_acquire_entropy(RAND_PO
              int attempts = 3;
              const int fd = get_random_device(i);
  
@@ -153,7 +153,7 @@ diff -up openssl-1.1.1i/crypto/rand/rand_unix.c.fips-post-rand openssl-1.1.1i/cr
  
              while (bytes_needed != 0 && attempts-- > 0) {
                  buffer = rand_pool_add_begin(pool, bytes_needed);
-@@ -742,7 +750,9 @@ size_t rand_pool_acquire_entropy(RAND_PO
+@@ -747,7 +755,9 @@ size_t rand_pool_acquire_entropy(RAND_PO
              return entropy_available;
      }
  #   endif
@@ -179,7 +179,7 @@ diff -up openssl-1.1.1i/include/crypto/fips.h.fips-post-rand openssl-1.1.1i/incl
 diff -up openssl-1.1.1i/include/crypto/rand.h.fips-post-rand openssl-1.1.1i/include/crypto/rand.h
 --- openssl-1.1.1i/include/crypto/rand.h.fips-post-rand	2020-12-08 14:20:59.000000000 +0100
 +++ openssl-1.1.1i/include/crypto/rand.h	2020-12-09 10:26:41.657106516 +0100
-@@ -24,6 +24,7 @@
+@@ -34,6 +34,7 @@
  typedef struct rand_pool_st RAND_POOL;
  
  void rand_cleanup_int(void);

--- a/rpm/openssl-1.1.1-fips.patch
+++ b/rpm/openssl-1.1.1-fips.patch
@@ -13,7 +13,7 @@ diff -up openssl-1.1.1j/apps/pkcs12.c.fips openssl-1.1.1j/apps/pkcs12.c
 diff -up openssl-1.1.1j/apps/speed.c.fips openssl-1.1.1j/apps/speed.c
 --- openssl-1.1.1j/apps/speed.c.fips	2021-03-03 12:57:42.185734409 +0100
 +++ openssl-1.1.1j/apps/speed.c	2021-03-03 12:57:42.195734492 +0100
-@@ -1593,7 +1593,8 @@ int speed_main(int argc, char **argv)
+@@ -1597,7 +1597,8 @@ int speed_main(int argc, char **argv)
              continue;
          if (strcmp(*argv, "rsa") == 0) {
              for (loop = 0; loop < OSSL_NELEM(rsa_doit); loop++)
@@ -23,7 +23,7 @@ diff -up openssl-1.1.1j/apps/speed.c.fips openssl-1.1.1j/apps/speed.c
              continue;
          }
          if (found(*argv, rsa_choices, &i)) {
-@@ -1603,7 +1604,9 @@ int speed_main(int argc, char **argv)
+@@ -1607,7 +1608,9 @@ int speed_main(int argc, char **argv)
  #endif
  #ifndef OPENSSL_NO_DSA
          if (strcmp(*argv, "dsa") == 0) {
@@ -34,7 +34,7 @@ diff -up openssl-1.1.1j/apps/speed.c.fips openssl-1.1.1j/apps/speed.c
                  dsa_doit[R_DSA_2048] = 1;
              continue;
          }
-@@ -1634,19 +1637,21 @@ int speed_main(int argc, char **argv)
+@@ -1638,19 +1641,21 @@ int speed_main(int argc, char **argv)
          }
          if (strcmp(*argv, "ecdh") == 0) {
              for (loop = 0; loop < OSSL_NELEM(ecdh_doit); loop++)
@@ -60,7 +60,7 @@ diff -up openssl-1.1.1j/apps/speed.c.fips openssl-1.1.1j/apps/speed.c
              eddsa_doit[i] = 2;
              continue;
          }
-@@ -1735,23 +1740,31 @@ int speed_main(int argc, char **argv)
+@@ -1739,23 +1744,31 @@ int speed_main(int argc, char **argv)
      /* No parameters; turn on everything. */
      if ((argc == 0) && !doit[D_EVP]) {
          for (i = 0; i < ALGOR_NUM; i++)
@@ -98,7 +98,7 @@ diff -up openssl-1.1.1j/apps/speed.c.fips openssl-1.1.1j/apps/speed.c
  #endif
      }
      for (i = 0; i < ALGOR_NUM; i++)
-@@ -1799,30 +1812,46 @@ int speed_main(int argc, char **argv)
+@@ -1803,30 +1816,46 @@ int speed_main(int argc, char **argv)
      AES_set_encrypt_key(key24, 192, &aes_ks2);
      AES_set_encrypt_key(key32, 256, &aes_ks3);
  #ifndef OPENSSL_NO_CAMELLIA
@@ -155,7 +155,7 @@ diff -up openssl-1.1.1j/apps/speed.c.fips openssl-1.1.1j/apps/speed.c
  #endif
  #ifndef SIGALRM
  # ifndef OPENSSL_NO_DES
-@@ -2120,6 +2149,7 @@ int speed_main(int argc, char **argv)
+@@ -2124,6 +2153,7 @@ int speed_main(int argc, char **argv)
  
          for (i = 0; i < loopargs_len; i++) {
              loopargs[i].hctx = HMAC_CTX_new();
@@ -190,7 +190,7 @@ diff -up openssl-1.1.1j/crypto/cmac/cm_pmeth.c.fips openssl-1.1.1j/crypto/cmac/c
 diff -up openssl-1.1.1j/crypto/dh/dh_err.c.fips openssl-1.1.1j/crypto/dh/dh_err.c
 --- openssl-1.1.1j/crypto/dh/dh_err.c.fips	2021-02-16 16:24:01.000000000 +0100
 +++ openssl-1.1.1j/crypto/dh/dh_err.c	2021-03-03 12:57:42.195734492 +0100
-@@ -25,6 +25,9 @@ static const ERR_STRING_DATA DH_str_func
+@@ -26,6 +26,9 @@ static const ERR_STRING_DATA DH_str_func
      {ERR_PACK(ERR_LIB_DH, DH_F_DH_CMS_SET_PEERKEY, 0), "dh_cms_set_peerkey"},
      {ERR_PACK(ERR_LIB_DH, DH_F_DH_CMS_SET_SHARED_INFO, 0),
       "dh_cms_set_shared_info"},
@@ -200,7 +200,7 @@ diff -up openssl-1.1.1j/crypto/dh/dh_err.c.fips openssl-1.1.1j/crypto/dh/dh_err.
      {ERR_PACK(ERR_LIB_DH, DH_F_DH_METH_DUP, 0), "DH_meth_dup"},
      {ERR_PACK(ERR_LIB_DH, DH_F_DH_METH_NEW, 0), "DH_meth_new"},
      {ERR_PACK(ERR_LIB_DH, DH_F_DH_METH_SET1_NAME, 0), "DH_meth_set1_name"},
-@@ -72,12 +75,14 @@ static const ERR_STRING_DATA DH_str_reas
+@@ -73,12 +76,14 @@ static const ERR_STRING_DATA DH_str_reas
      {ERR_PACK(ERR_LIB_DH, 0, DH_R_INVALID_PUBKEY), "invalid public key"},
      {ERR_PACK(ERR_LIB_DH, 0, DH_R_KDF_PARAMETER_ERROR), "kdf parameter error"},
      {ERR_PACK(ERR_LIB_DH, 0, DH_R_KEYS_NOT_SET), "keys not set"},
@@ -872,7 +872,7 @@ diff -up openssl-1.1.1j/crypto/evp/digest.c.fips openssl-1.1.1j/crypto/evp/diges
  
  
  static void cleanup_old_md_data(EVP_MD_CTX *ctx, int force)
-@@ -66,6 +69,12 @@ int EVP_DigestInit(EVP_MD_CTX *ctx, cons
+@@ -77,6 +80,12 @@ int EVP_DigestInit(EVP_MD_CTX *ctx, cons
  int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
  {
      EVP_MD_CTX_clear_flags(ctx, EVP_MD_CTX_FLAG_CLEANED);
@@ -885,7 +885,7 @@ diff -up openssl-1.1.1j/crypto/evp/digest.c.fips openssl-1.1.1j/crypto/evp/diges
  #ifndef OPENSSL_NO_ENGINE
      /*
       * Whether it's nice or not, "Inits" can be used on "Final"'d contexts so
-@@ -119,6 +128,15 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, c
+@@ -131,6 +140,15 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, c
      }
  #endif
      if (ctx->digest != type) {
@@ -901,7 +901,7 @@ diff -up openssl-1.1.1j/crypto/evp/digest.c.fips openssl-1.1.1j/crypto/evp/diges
          cleanup_old_md_data(ctx, 1);
  
          ctx->digest = type;
-@@ -150,6 +168,10 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, c
+@@ -160,6 +178,10 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, c
  
  int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
  {
@@ -912,7 +912,7 @@ diff -up openssl-1.1.1j/crypto/evp/digest.c.fips openssl-1.1.1j/crypto/evp/diges
      if (count == 0)
          return 1;
  
-@@ -170,6 +192,9 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx,
+@@ -180,6 +202,9 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx,
  {
      int ret;
  
@@ -943,7 +943,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
              EVPerr(EVP_F_AES_T4_XTS_INIT_KEY, EVP_R_XTS_DUPLICATED_KEYS);
              return 0;
          }
-@@ -2833,9 +2833,9 @@ static int aes_ctr_cipher(EVP_CIPHER_CTX
+@@ -2827,9 +2827,9 @@ static int aes_ctr_cipher(EVP_CIPHER_CTX
      return 1;
  }
  
@@ -956,7 +956,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
  
  static int aes_gcm_cleanup(EVP_CIPHER_CTX *c)
  {
-@@ -2869,6 +2869,11 @@ static int aes_gcm_ctrl(EVP_CIPHER_CTX *
+@@ -2863,6 +2863,11 @@ static int aes_gcm_ctrl(EVP_CIPHER_CTX *
      case EVP_CTRL_AEAD_SET_IVLEN:
          if (arg <= 0)
              return 0;
@@ -968,7 +968,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
          /* Allocate memory for IV if needed */
          if ((arg > EVP_MAX_IV_LENGTH) && (arg > gctx->ivlen)) {
              if (gctx->iv != c->iv)
-@@ -3318,11 +3323,14 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX
+@@ -3312,11 +3317,14 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX
                  | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_CUSTOM_IV_LENGTH)
  
  BLOCK_CIPHER_custom(NID_aes, 128, 1, 12, gcm, GCM,
@@ -986,7 +986,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
  
  static int aes_xts_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
  {
-@@ -3380,7 +3388,7 @@ static int aes_xts_init_key(EVP_CIPHER_C
+@@ -3374,7 +3382,7 @@ static int aes_xts_init_key(EVP_CIPHER_C
               *       BEFORE using the keys in the XTS-AES algorithm to process
               *       data with them."
               */
@@ -995,7 +995,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
                  EVPerr(EVP_F_AES_XTS_INIT_KEY, EVP_R_XTS_DUPLICATED_KEYS);
                  return 0;
              }
-@@ -3484,6 +3492,14 @@ static int aes_xts_cipher(EVP_CIPHER_CTX
+@@ -3478,6 +3486,14 @@ static int aes_xts_cipher(EVP_CIPHER_CTX
          return 0;
      if (!out || !in || len < AES_BLOCK_SIZE)
          return 0;
@@ -1010,7 +1010,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
      if (xctx->stream)
          (*xctx->stream) (in, out, len,
                           xctx->xts.key1, xctx->xts.key2,
-@@ -3501,8 +3517,10 @@ static int aes_xts_cipher(EVP_CIPHER_CTX
+@@ -3495,8 +3511,10 @@ static int aes_xts_cipher(EVP_CIPHER_CTX
                           | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT \
                           | EVP_CIPH_CUSTOM_COPY)
  
@@ -1023,7 +1023,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
  
  static int aes_ccm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
  {
-@@ -3772,11 +3790,11 @@ static int aes_ccm_cipher(EVP_CIPHER_CTX
+@@ -3766,11 +3784,11 @@ static int aes_ccm_cipher(EVP_CIPHER_CTX
  #define aes_ccm_cleanup NULL
  
  BLOCK_CIPHER_custom(NID_aes, 128, 1, 12, ccm, CCM,
@@ -1038,7 +1038,7 @@ diff -up openssl-1.1.1j/crypto/evp/e_aes.c.fips openssl-1.1.1j/crypto/evp/e_aes.
  
  typedef struct {
      union {
-@@ -3869,7 +3887,7 @@ static int aes_wrap_cipher(EVP_CIPHER_CT
+@@ -3863,7 +3881,7 @@ static int aes_wrap_cipher(EVP_CIPHER_CT
      return rv ? (int)rv : -1;
  }
  
@@ -9705,7 +9705,7 @@ diff -up openssl-1.1.1j/crypto/rand/rand_lib.c.fips openssl-1.1.1j/crypto/rand/r
  
  #ifndef OPENSSL_NO_ENGINE
  /* non-NULL if default_RAND_meth is ENGINE-provided */
-@@ -959,3 +963,15 @@ int RAND_status(void)
+@@ -967,3 +971,15 @@ int RAND_status(void)
          return meth->status();
      return 0;
  }
@@ -10338,7 +10338,7 @@ diff -up openssl-1.1.1j/crypto/rsa/rsa_ossl.c.fips openssl-1.1.1j/crypto/rsa/rsa
      if (BN_num_bits(rsa->n) > OPENSSL_RSA_MAX_MODULUS_BITS) {
          RSAerr(RSA_F_RSA_OSSL_PUBLIC_ENCRYPT, RSA_R_MODULUS_TOO_LARGE);
          return -1;
-@@ -246,6 +272,22 @@ static int rsa_ossl_private_encrypt(int
+@@ -247,6 +273,22 @@ static int rsa_ossl_private_encrypt(int
      BIGNUM *unblind = NULL;
      BN_BLINDING *blinding = NULL;
  
@@ -10361,7 +10361,7 @@ diff -up openssl-1.1.1j/crypto/rsa/rsa_ossl.c.fips openssl-1.1.1j/crypto/rsa/rsa
      if ((ctx = BN_CTX_new()) == NULL)
          goto err;
      BN_CTX_start(ctx);
-@@ -380,6 +422,22 @@ static int rsa_ossl_private_decrypt(int
+@@ -381,6 +423,22 @@ static int rsa_ossl_private_decrypt(int
      BIGNUM *unblind = NULL;
      BN_BLINDING *blinding = NULL;
  
@@ -10384,7 +10384,7 @@ diff -up openssl-1.1.1j/crypto/rsa/rsa_ossl.c.fips openssl-1.1.1j/crypto/rsa/rsa
      if ((ctx = BN_CTX_new()) == NULL)
          goto err;
      BN_CTX_start(ctx);
-@@ -507,6 +565,22 @@ static int rsa_ossl_public_decrypt(int f
+@@ -506,6 +564,22 @@ static int rsa_ossl_public_decrypt(int f
      unsigned char *buf = NULL;
      BN_CTX *ctx = NULL;
  
@@ -10652,7 +10652,7 @@ diff -up openssl-1.1.1j/include/openssl/crypto.h.fips openssl-1.1.1j/include/ope
 diff -up openssl-1.1.1j/include/openssl/dherr.h.fips openssl-1.1.1j/include/openssl/dherr.h
 --- openssl-1.1.1j/include/openssl/dherr.h.fips	2021-02-16 16:24:01.000000000 +0100
 +++ openssl-1.1.1j/include/openssl/dherr.h	2021-03-03 12:57:42.204734567 +0100
-@@ -36,6 +36,9 @@ int ERR_load_DH_strings(void);
+@@ -37,6 +37,9 @@ int ERR_load_DH_strings(void);
  #  define DH_F_DH_CMS_DECRYPT                              114
  #  define DH_F_DH_CMS_SET_PEERKEY                          115
  #  define DH_F_DH_CMS_SET_SHARED_INFO                      116
@@ -10662,7 +10662,7 @@ diff -up openssl-1.1.1j/include/openssl/dherr.h.fips openssl-1.1.1j/include/open
  #  define DH_F_DH_METH_DUP                                 117
  #  define DH_F_DH_METH_NEW                                 118
  #  define DH_F_DH_METH_SET1_NAME                           119
-@@ -73,12 +76,14 @@ int ERR_load_DH_strings(void);
+@@ -74,12 +77,14 @@ int ERR_load_DH_strings(void);
  #  define DH_R_INVALID_PARAMETER_NID                       114
  #  define DH_R_INVALID_PUBKEY                              102
  #  define DH_R_KDF_PARAMETER_ERROR                         112
@@ -10680,7 +10680,7 @@ diff -up openssl-1.1.1j/include/openssl/dherr.h.fips openssl-1.1.1j/include/open
 diff -up openssl-1.1.1j/include/openssl/dh.h.fips openssl-1.1.1j/include/openssl/dh.h
 --- openssl-1.1.1j/include/openssl/dh.h.fips	2021-02-16 16:24:01.000000000 +0100
 +++ openssl-1.1.1j/include/openssl/dh.h	2021-03-03 12:57:42.204734567 +0100
-@@ -31,6 +31,7 @@ extern "C" {
+@@ -34,6 +34,7 @@ extern "C" {
  # endif
  
  # define OPENSSL_DH_FIPS_MIN_MODULUS_BITS 1024
@@ -11360,7 +11360,7 @@ diff -up openssl-1.1.1j/ssl/ssl_ciph.c.fips openssl-1.1.1j/ssl/ssl_ciph.c
          if ((c->algorithm_mkey & disabled_mkey) ||
              (c->algorithm_auth & disabled_auth) ||
              (c->algorithm_enc & disabled_enc) ||
-@@ -1671,7 +1676,8 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1669,7 +1674,8 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * to the resulting precedence to the STACK_OF(SSL_CIPHER).
       */
      for (curr = head; curr != NULL; curr = curr->next) {
@@ -11419,7 +11419,7 @@ diff -up openssl-1.1.1j/ssl/ssl_init.c.fips openssl-1.1.1j/ssl/ssl_init.c
 diff -up openssl-1.1.1j/ssl/ssl_lib.c.fips openssl-1.1.1j/ssl/ssl_lib.c
 --- openssl-1.1.1j/ssl/ssl_lib.c.fips	2021-03-03 12:57:42.193734476 +0100
 +++ openssl-1.1.1j/ssl/ssl_lib.c	2021-03-03 12:57:42.206734583 +0100
-@@ -2973,6 +2973,11 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
+@@ -3040,6 +3040,11 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
      if (!OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL))
          return NULL;
  
@@ -11431,7 +11431,7 @@ diff -up openssl-1.1.1j/ssl/ssl_lib.c.fips openssl-1.1.1j/ssl/ssl_lib.c
      if (SSL_get_ex_data_X509_STORE_CTX_idx() < 0) {
          SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_X509_VERIFICATION_SETUP_PROBLEMS);
          goto err;
-@@ -3029,13 +3034,17 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
+@@ -3096,13 +3101,17 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
      if (ret->param == NULL)
          goto err;
  
@@ -11583,7 +11583,7 @@ diff -up openssl-1.1.1j/test/dsatest.c.fips openssl-1.1.1j/test/dsatest.c
 diff -up openssl-1.1.1j/test/recipes/30-test_evp_data/evpciph.txt.fips openssl-1.1.1j/test/recipes/30-test_evp_data/evpciph.txt
 --- openssl-1.1.1j/test/recipes/30-test_evp_data/evpciph.txt.fips	2021-02-16 16:24:01.000000000 +0100
 +++ openssl-1.1.1j/test/recipes/30-test_evp_data/evpciph.txt	2021-03-03 12:57:42.207734591 +0100
-@@ -1206,6 +1206,7 @@ Key = 0000000000000000000000000000000000
+@@ -1256,6 +1256,7 @@ Key = 0000000000000000000000000000000000
  IV = 00000000000000000000000000000000
  Plaintext = 0000000000000000000000000000000000000000000000000000000000000000
  Ciphertext = 917cf69ebd68b2ec9b9fe9a3eadda692cd43d2f59598ed858c02c2652fbf922e

--- a/rpm/openssl-1.1.1-krb5-kdf.patch
+++ b/rpm/openssl-1.1.1-krb5-kdf.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1d/crypto/err/openssl.txt.krb5-kdf openssl-1.1.1d/crypto/err/openssl.txt
 --- openssl-1.1.1d/crypto/err/openssl.txt.krb5-kdf	2019-11-14 15:07:05.320094521 +0100
 +++ openssl-1.1.1d/crypto/err/openssl.txt	2019-11-14 15:07:05.342094129 +0100
-@@ -821,6 +821,11 @@ EVP_F_S390X_AES_GCM_CTRL:201:s390x_aes_g
+@@ -835,6 +835,11 @@ EVP_F_S390X_AES_GCM_CTRL:201:s390x_aes_g
  EVP_F_SCRYPT_ALG:228:scrypt_alg
  EVP_F_UPDATE:173:update
  KDF_F_HKDF_EXTRACT:112:HKDF_Extract
@@ -13,7 +13,7 @@ diff -up openssl-1.1.1d/crypto/err/openssl.txt.krb5-kdf openssl-1.1.1d/crypto/er
  KDF_F_KDF_HKDF_DERIVE:113:kdf_hkdf_derive
  KDF_F_KDF_HKDF_NEW:114:kdf_hkdf_new
  KDF_F_KDF_HKDF_SIZE:115:kdf_hkdf_size
-@@ -840,6 +845,8 @@ KDF_F_KDF_SSHKDF_NEW:133:kdf_sshkdf_new
+@@ -854,6 +859,8 @@ KDF_F_KDF_SSHKDF_NEW:133:kdf_sshkdf_new
  KDF_F_KDF_TLS1_PRF_CTRL_STR:125:kdf_tls1_prf_ctrl_str
  KDF_F_KDF_TLS1_PRF_DERIVE:126:kdf_tls1_prf_derive
  KDF_F_KDF_TLS1_PRF_NEW:127:kdf_tls1_prf_new
@@ -22,7 +22,7 @@ diff -up openssl-1.1.1d/crypto/err/openssl.txt.krb5-kdf openssl-1.1.1d/crypto/er
  KDF_F_PBKDF2_SET_MEMBUF:128:pbkdf2_set_membuf
  KDF_F_PKEY_HKDF_CTRL_STR:103:pkey_hkdf_ctrl_str
  KDF_F_PKEY_HKDF_DERIVE:102:pkey_hkdf_derive
-@@ -853,6 +860,9 @@ KDF_F_PKEY_TLS1_PRF_CTRL_STR:100:pkey_tl
+@@ -867,6 +874,9 @@ KDF_F_PKEY_TLS1_PRF_CTRL_STR:100:pkey_tl
  KDF_F_PKEY_TLS1_PRF_DERIVE:101:pkey_tls1_prf_derive
  KDF_F_PKEY_TLS1_PRF_INIT:110:pkey_tls1_prf_init
  KDF_F_SCRYPT_SET_MEMBUF:129:scrypt_set_membuf
@@ -32,7 +32,7 @@ diff -up openssl-1.1.1d/crypto/err/openssl.txt.krb5-kdf openssl-1.1.1d/crypto/er
  KDF_F_TLS1_PRF_ALG:111:tls1_prf_alg
  OBJ_F_OBJ_ADD_OBJECT:105:OBJ_add_object
  OBJ_F_OBJ_ADD_SIGID:107:OBJ_add_sigid
-@@ -2325,7 +2335,13 @@ EVP_R_UNSUPPORTED_SALT_TYPE:126:unsuppor
+@@ -2355,7 +2365,13 @@ EVP_R_UNSUPPORTED_SALT_TYPE:126:unsuppor
  EVP_R_WRAP_MODE_NOT_ALLOWED:170:wrap mode not allowed
  EVP_R_WRONG_FINAL_BLOCK_LENGTH:109:wrong final block length
  EVP_R_XTS_DUPLICATED_KEYS:183:xts duplicated keys
@@ -46,7 +46,7 @@ diff -up openssl-1.1.1d/crypto/err/openssl.txt.krb5-kdf openssl-1.1.1d/crypto/er
  KDF_R_MISSING_ITERATION_COUNT:109:missing iteration count
  KDF_R_MISSING_KEY:104:missing key
  KDF_R_MISSING_MESSAGE_DIGEST:105:missing message digest
-@@ -2340,6 +2356,7 @@ KDF_R_MISSING_XCGHASH:115:missing xcghas
+@@ -2370,6 +2386,7 @@ KDF_R_MISSING_XCGHASH:115:missing xcghas
  KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
  KDF_R_VALUE_ERROR:108:value error
  KDF_R_VALUE_MISSING:102:value missing

--- a/rpm/openssl-1.1.1-man-rename.patch
+++ b/rpm/openssl-1.1.1-man-rename.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1-pre9/doc/man1/openssl.pod.man-rename openssl-1.1.1-pre9/doc/man1/openssl.pod
 --- openssl-1.1.1-pre9/doc/man1/openssl.pod.man-rename	2018-08-21 14:14:13.000000000 +0200
 +++ openssl-1.1.1-pre9/doc/man1/openssl.pod	2018-08-22 12:13:04.092568064 +0200
-@@ -482,13 +482,13 @@ L<dhparam(1)>, L<dsa(1)>, L<dsaparam(1)>
+@@ -539,13 +539,13 @@ L<dhparam(1)>, L<dsa(1)>, L<dsaparam(1)>
  L<ec(1)>, L<ecparam(1)>,
  L<enc(1)>, L<engine(1)>, L<errstr(1)>, L<gendsa(1)>, L<genpkey(1)>,
  L<genrsa(1)>, L<nseq(1)>, L<ocsp(1)>,

--- a/rpm/openssl-1.1.1-no-brainpool.patch
+++ b/rpm/openssl-1.1.1-no-brainpool.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1d/test/ssl-tests/20-cert-select.conf.in.no-brainpool openssl-1.1.1d/test/ssl-tests/20-cert-select.conf.in
 --- openssl-1.1.1d/test/ssl-tests/20-cert-select.conf.in.no-brainpool	2019-09-10 15:13:07.000000000 +0200
 +++ openssl-1.1.1d/test/ssl-tests/20-cert-select.conf.in	2019-09-13 15:11:07.358687169 +0200
-@@ -147,22 +147,22 @@ our @tests = (
+@@ -148,22 +148,22 @@ our @tests = (
      {
          name => "ECDSA with brainpool",
          server =>  {
@@ -31,7 +31,7 @@ diff -up openssl-1.1.1d/test/ssl-tests/20-cert-select.conf.in.no-brainpool opens
              "ExpectedResult" => "Success"
          },
      },
-@@ -853,18 +853,18 @@ my @tests_tls_1_3 = (
+@@ -856,18 +856,18 @@ my @tests_tls_1_3 = (
      {
          name => "TLS 1.3 ECDSA with brainpool",
          server =>  {

--- a/rpm/openssl-1.1.1-no-html.patch
+++ b/rpm/openssl-1.1.1-no-html.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1f/Configurations/unix-Makefile.tmpl.no-html openssl-1.1.1f/Configurations/unix-Makefile.tmpl
 --- openssl-1.1.1f/Configurations/unix-Makefile.tmpl.no-html	2020-04-07 16:45:21.904083989 +0200
 +++ openssl-1.1.1f/Configurations/unix-Makefile.tmpl	2020-04-07 16:45:56.218461895 +0200
-@@ -544,7 +544,7 @@ install_sw: install_dev install_engines
+@@ -543,7 +543,7 @@ install_sw: install_dev install_engines
  
  uninstall_sw: uninstall_runtime uninstall_engines uninstall_dev
  

--- a/rpm/openssl-1.1.1-s390x-ecc.patch
+++ b/rpm/openssl-1.1.1-s390x-ecc.patch
@@ -12,7 +12,7 @@ diff -up openssl-1.1.1g/Configurations/00-base-templates.conf.s390x-ecc openssl-
 diff -up openssl-1.1.1g/Configure.s390x-ecc openssl-1.1.1g/Configure
 --- openssl-1.1.1g/Configure.s390x-ecc	2020-05-18 12:45:40.781233618 +0200
 +++ openssl-1.1.1g/Configure	2020-05-18 12:45:40.856234270 +0200
-@@ -1398,6 +1398,9 @@ unless ($disabled{asm}) {
+@@ -1418,6 +1418,9 @@ unless ($disabled{asm}) {
      if ($target{ec_asm_src} =~ /ecp_nistz256/) {
          push @{$config{lib_defines}}, "ECP_NISTZ256_ASM";
      }
@@ -429,7 +429,7 @@ diff -up openssl-1.1.1g/crypto/ec/ec_local.h.s390x-ecc openssl-1.1.1g/crypto/ec/
      /* Inverse modulo order */
      int (*field_inverse_mod_ord)(const EC_GROUP *, BIGNUM *r,
                                   const BIGNUM *x, BN_CTX *);
-@@ -587,6 +595,11 @@ int ec_group_simple_order_bits(const EC_
+@@ -589,6 +597,11 @@ int ec_group_simple_order_bits(const EC_
   */
  const EC_METHOD *EC_GFp_nistz256_method(void);
  #endif
@@ -441,7 +441,7 @@ diff -up openssl-1.1.1g/crypto/ec/ec_local.h.s390x-ecc openssl-1.1.1g/crypto/ec/
  
  size_t ec_key_simple_priv2oct(const EC_KEY *eckey,
                                unsigned char *buf, size_t len);
-@@ -651,6 +664,13 @@ int ossl_ecdsa_verify(int type, const un
+@@ -653,6 +666,13 @@ int ossl_ecdsa_verify(int type, const un
                        const unsigned char *sigbuf, int sig_len, EC_KEY *eckey);
  int ossl_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
                            const ECDSA_SIG *sig, EC_KEY *eckey);
@@ -496,7 +496,7 @@ diff -up openssl-1.1.1g/crypto/ec/ecp_nist.c.s390x-ecc openssl-1.1.1g/crypto/ec/
 diff -up openssl-1.1.1g/crypto/ec/ecp_nistp224.c.s390x-ecc openssl-1.1.1g/crypto/ec/ecp_nistp224.c
 --- openssl-1.1.1g/crypto/ec/ecp_nistp224.c.s390x-ecc	2020-04-21 14:22:39.000000000 +0200
 +++ openssl-1.1.1g/crypto/ec/ecp_nistp224.c	2020-05-18 12:45:44.568266531 +0200
-@@ -292,6 +292,9 @@ const EC_METHOD *EC_GFp_nistp224_method(
+@@ -293,6 +293,9 @@ const EC_METHOD *EC_GFp_nistp224_method(
          0, /* keycopy */
          0, /* keyfinish */
          ecdh_simple_compute_key,
@@ -522,7 +522,7 @@ diff -up openssl-1.1.1g/crypto/ec/ecp_nistp256.c.s390x-ecc openssl-1.1.1g/crypto
 diff -up openssl-1.1.1g/crypto/ec/ecp_nistp521.c.s390x-ecc openssl-1.1.1g/crypto/ec/ecp_nistp521.c
 --- openssl-1.1.1g/crypto/ec/ecp_nistp521.c.s390x-ecc	2020-04-21 14:22:39.000000000 +0200
 +++ openssl-1.1.1g/crypto/ec/ecp_nistp521.c	2020-05-18 12:45:44.569266540 +0200
-@@ -1669,6 +1669,9 @@ const EC_METHOD *EC_GFp_nistp521_method(
+@@ -1670,6 +1670,9 @@ const EC_METHOD *EC_GFp_nistp521_method(
          0, /* keycopy */
          0, /* keyfinish */
          ecdh_simple_compute_key,
@@ -535,7 +535,7 @@ diff -up openssl-1.1.1g/crypto/ec/ecp_nistp521.c.s390x-ecc openssl-1.1.1g/crypto
 diff -up openssl-1.1.1g/crypto/ec/ecp_nistz256.c.s390x-ecc openssl-1.1.1g/crypto/ec/ecp_nistz256.c
 --- openssl-1.1.1g/crypto/ec/ecp_nistz256.c.s390x-ecc	2020-04-21 14:22:39.000000000 +0200
 +++ openssl-1.1.1g/crypto/ec/ecp_nistz256.c	2020-05-18 12:45:44.570266549 +0200
-@@ -1720,6 +1720,9 @@ const EC_METHOD *EC_GFp_nistz256_method(
+@@ -1513,6 +1513,9 @@ const EC_METHOD *EC_GFp_nistz256_method(
          0, /* keycopy */
          0, /* keyfinish */
          ecdh_simple_compute_key,
@@ -1637,7 +1637,7 @@ diff -up openssl-1.1.1g/crypto/ec/ecx_meth.c.s390x-ecc openssl-1.1.1g/crypto/ec/
 diff -up openssl-1.1.1g/crypto/err/openssl.txt.s390x-ecc openssl-1.1.1g/crypto/err/openssl.txt
 --- openssl-1.1.1g/crypto/err/openssl.txt.s390x-ecc	2020-05-18 12:45:40.834234079 +0200
 +++ openssl-1.1.1g/crypto/err/openssl.txt	2020-05-18 12:45:44.575266592 +0200
-@@ -496,6 +496,11 @@ EC_F_ECDSA_SIGN_EX:254:ECDSA_sign_ex
+@@ -498,6 +498,11 @@ EC_F_ECDSA_SIGN_EX:254:ECDSA_sign_ex
  EC_F_ECDSA_SIGN_SETUP:248:ECDSA_sign_setup
  EC_F_ECDSA_SIG_NEW:265:ECDSA_SIG_new
  EC_F_ECDSA_VERIFY:253:ECDSA_verify
@@ -1649,7 +1649,7 @@ diff -up openssl-1.1.1g/crypto/err/openssl.txt.s390x-ecc openssl-1.1.1g/crypto/e
  EC_F_ECD_ITEM_VERIFY:270:ecd_item_verify
  EC_F_ECKEY_PARAM2TYPE:223:eckey_param2type
  EC_F_ECKEY_PARAM_DECODE:212:eckey_param_decode
-@@ -657,6 +662,7 @@ EC_F_NISTP521_PRE_COMP_NEW:237:nistp521_
+@@ -659,6 +664,7 @@ EC_F_NISTP521_PRE_COMP_NEW:237:nistp521_
  EC_F_O2I_ECPUBLICKEY:152:o2i_ECPublicKey
  EC_F_OLD_EC_PRIV_DECODE:222:old_ec_priv_decode
  EC_F_OSSL_ECDH_COMPUTE_KEY:247:ossl_ecdh_compute_key
@@ -1657,7 +1657,7 @@ diff -up openssl-1.1.1g/crypto/err/openssl.txt.s390x-ecc openssl-1.1.1g/crypto/e
  EC_F_OSSL_ECDSA_SIGN_SIG:249:ossl_ecdsa_sign_sig
  EC_F_OSSL_ECDSA_VERIFY_SIG:250:ossl_ecdsa_verify_sig
  EC_F_PKEY_ECD_CTRL:271:pkey_ecd_ctrl
-@@ -672,6 +678,12 @@ EC_F_PKEY_EC_KDF_DERIVE:283:pkey_ec_kdf_
+@@ -674,6 +680,12 @@ EC_F_PKEY_EC_KDF_DERIVE:283:pkey_ec_kdf_
  EC_F_PKEY_EC_KEYGEN:199:pkey_ec_keygen
  EC_F_PKEY_EC_PARAMGEN:219:pkey_ec_paramgen
  EC_F_PKEY_EC_SIGN:218:pkey_ec_sign
@@ -1670,7 +1670,7 @@ diff -up openssl-1.1.1g/crypto/err/openssl.txt.s390x-ecc openssl-1.1.1g/crypto/e
  EC_F_VALIDATE_ECX_DERIVE:278:validate_ecx_derive
  ENGINE_F_DIGEST_UPDATE:198:digest_update
  ENGINE_F_DYNAMIC_CTRL:180:dynamic_ctrl
-@@ -2160,6 +2172,7 @@ EC_R_BUFFER_TOO_SMALL:100:buffer too sma
+@@ -2171,6 +2183,7 @@ EC_R_BUFFER_TOO_SMALL:100:buffer too sma
  EC_R_CANNOT_INVERT:165:cannot invert
  EC_R_COORDINATES_OUT_OF_RANGE:146:coordinates out of range
  EC_R_CURVE_DOES_NOT_SUPPORT_ECDH:160:curve does not support ecdh
@@ -1928,7 +1928,7 @@ diff -up openssl-1.1.1g/crypto/s390x_arch.h.s390x-ecc openssl-1.1.1g/crypto/s390
  };
  
  #if defined(__GNUC__) && defined(__linux)
-@@ -66,11 +74,14 @@ extern struct OPENSSL_s390xcap_st OPENSS
+@@ -69,11 +77,14 @@ extern struct OPENSSL_s390xcap_st OPENSS
  # define S390X_KMF		0x90
  # define S390X_PRNO		0xa0
  # define S390X_KMA		0xb0
@@ -1943,7 +1943,7 @@ diff -up openssl-1.1.1g/crypto/s390x_arch.h.s390x-ecc openssl-1.1.1g/crypto/s390
  
  /* Function Codes */
  
-@@ -94,10 +105,32 @@ extern struct OPENSSL_s390xcap_st OPENSS
+@@ -97,10 +108,32 @@ extern struct OPENSSL_s390xcap_st OPENSS
  /* prno */
  # define S390X_TRNG		114
  

--- a/rpm/openssl-1.1.1-seclevel.patch
+++ b/rpm/openssl-1.1.1-seclevel.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1g/crypto/x509/x509_vfy.c.seclevel openssl-1.1.1g/crypto/x509/x509_vfy.c
 --- openssl-1.1.1g/crypto/x509/x509_vfy.c.seclevel	2020-04-21 14:22:39.000000000 +0200
 +++ openssl-1.1.1g/crypto/x509/x509_vfy.c	2020-06-05 17:16:54.835536823 +0200
-@@ -3225,6 +3225,7 @@ static int build_chain(X509_STORE_CTX *c
+@@ -3315,6 +3315,7 @@ static int build_chain(X509_STORE_CTX *c
  }
  
  static const int minbits_table[] = { 80, 112, 128, 192, 256 };
@@ -9,7 +9,7 @@ diff -up openssl-1.1.1g/crypto/x509/x509_vfy.c.seclevel openssl-1.1.1g/crypto/x5
  static const int NUM_AUTH_LEVELS = OSSL_NELEM(minbits_table);
  
  /*
-@@ -3276,6 +3277,11 @@ static int check_sig_level(X509_STORE_CT
+@@ -3392,6 +3393,11 @@ static int check_sig_level(X509_STORE_CT
  
      if (!X509_get_signature_info(cert, NULL, NULL, &secbits, NULL))
          return 0;
@@ -59,7 +59,7 @@ diff -up openssl-1.1.1g/ssl/ssl_cert.c.seclevel openssl-1.1.1g/ssl/ssl_cert.c
      if (!X509_STORE_CTX_set_ex_data
          (ctx, SSL_get_ex_data_X509_STORE_CTX_idx(), s)) {
          goto end;
-@@ -953,12 +954,33 @@ static int ssl_security_default_callback
+@@ -975,12 +976,33 @@ static int ssl_security_default_callback
              return 0;
          break;
      default:
@@ -107,7 +107,7 @@ diff -up openssl-1.1.1g/ssl/ssl_local.h.seclevel openssl-1.1.1g/ssl/ssl_local.h
 diff -up openssl-1.1.1g/ssl/t1_lib.c.seclevel openssl-1.1.1g/ssl/t1_lib.c
 --- openssl-1.1.1g/ssl/t1_lib.c.seclevel	2020-06-04 15:48:01.654179221 +0200
 +++ openssl-1.1.1g/ssl/t1_lib.c	2020-06-05 17:02:40.268459157 +0200
-@@ -2145,6 +2145,36 @@ int tls1_set_sigalgs(CERT *c, const int
+@@ -2105,6 +2105,36 @@ int tls1_set_sigalgs(CERT *c, const int
      return 0;
  }
  
@@ -147,7 +147,7 @@ diff -up openssl-1.1.1g/ssl/t1_lib.c.seclevel openssl-1.1.1g/ssl/t1_lib.c
 diff -up openssl-1.1.1g/test/recipes/25-test_verify.t.seclevel openssl-1.1.1g/test/recipes/25-test_verify.t
 --- openssl-1.1.1g/test/recipes/25-test_verify.t.seclevel	2020-04-21 14:22:39.000000000 +0200
 +++ openssl-1.1.1g/test/recipes/25-test_verify.t	2020-06-04 15:48:01.608178833 +0200
-@@ -346,8 +346,8 @@ ok(verify("ee-pss-sha1-cert", "sslserver
+@@ -371,8 +371,8 @@ ok(verify("ee-pss-sha1-cert", "sslserver
  ok(verify("ee-pss-sha256-cert", "sslserver", ["root-cert"], ["ca-cert"], ),
      "CA with PSS signature using SHA256");
  

--- a/rpm/openssl-1.1.1-ssh-kdf.patch
+++ b/rpm/openssl-1.1.1-ssh-kdf.patch
@@ -16,7 +16,7 @@ diff --git a/crypto/err/openssl.txt b/crypto/err/openssl.txt
 index ae67dac7f6..e7ed2f8d63 100644
 --- a/crypto/err/openssl.txt
 +++ b/crypto/err/openssl.txt
-@@ -828,6 +828,10 @@ KDF_F_KDF_SCRYPT_CTRL_UINT32:121:kdf_scrypt_ctrl_uint32
+@@ -835,6 +835,10 @@ KDF_F_KDF_SCRYPT_CTRL_UINT32:121:kdf_scrypt_ctrl_uint32
  KDF_F_KDF_SCRYPT_CTRL_UINT64:122:kdf_scrypt_ctrl_uint64
  KDF_F_KDF_SCRYPT_DERIVE:123:kdf_scrypt_derive
  KDF_F_KDF_SCRYPT_NEW:124:kdf_scrypt_new
@@ -27,7 +27,7 @@ index ae67dac7f6..e7ed2f8d63 100644
  KDF_F_KDF_TLS1_PRF_CTRL_STR:125:kdf_tls1_prf_ctrl_str
  KDF_F_KDF_TLS1_PRF_DERIVE:126:kdf_tls1_prf_derive
  KDF_F_KDF_TLS1_PRF_NEW:127:kdf_tls1_prf_new
-@@ -2320,6 +2324,9 @@ KDF_R_MISSING_PASS:110:missing pass
+@@ -2347,6 +2351,9 @@ KDF_R_MISSING_PASS:110:missing pass
  KDF_R_MISSING_SALT:111:missing salt
  KDF_R_MISSING_SECRET:107:missing secret
  KDF_R_MISSING_SEED:106:missing seed
@@ -683,7 +683,7 @@ diff --git a/include/openssl/kdferr.h b/include/openssl/kdferr.h
 index 0191f2b21d..ff13ccb649 100644
 --- a/include/openssl/kdferr.h
 +++ b/include/openssl/kdferr.h
-@@ -32,6 +32,10 @@ int ERR_load_KDF_strings(void);
+@@ -36,6 +36,10 @@ int ERR_load_KDF_strings(void);
  # define KDF_F_KDF_SCRYPT_CTRL_UINT64                     122
  # define KDF_F_KDF_SCRYPT_DERIVE                          123
  # define KDF_F_KDF_SCRYPT_NEW                             124
@@ -694,7 +694,7 @@ index 0191f2b21d..ff13ccb649 100644
  # define KDF_F_KDF_TLS1_PRF_CTRL_STR                      125
  # define KDF_F_KDF_TLS1_PRF_DERIVE                        126
  # define KDF_F_KDF_TLS1_PRF_NEW                           127
-@@ -62,6 +66,9 @@ int ERR_load_KDF_strings(void);
+@@ -66,6 +70,9 @@ int ERR_load_KDF_strings(void);
  # define KDF_R_MISSING_SALT                               111
  # define KDF_R_MISSING_SECRET                             107
  # define KDF_R_MISSING_SEED                               106
@@ -5600,7 +5600,7 @@ diff --git a/crypto/kdf/sshkdf.c b/crypto/kdf/sshkdf.c
 index 300e1adbb23..f585e8a0d6d 100644
 --- a/crypto/kdf/sshkdf.c
 +++ b/crypto/kdf/sshkdf.c
-@@ -125,6 +125,9 @@ static int kdf_sshkdf_ctrl_str(EVP_KDF_IMPL *impl, const char *type,
+@@ -124,6 +124,9 @@ static int kdf_sshkdf_ctrl_str(EVP_KDF_IMPL *impl, const char *type,
          return 0;
      }
  

--- a/rpm/openssl-1.1.1-system-cipherlist.patch
+++ b/rpm/openssl-1.1.1-system-cipherlist.patch
@@ -1,7 +1,7 @@
 diff -up openssl-1.1.1c/Configurations/unix-Makefile.tmpl.system-cipherlist openssl-1.1.1c/Configurations/unix-Makefile.tmpl
 --- openssl-1.1.1c/Configurations/unix-Makefile.tmpl.system-cipherlist	2019-05-29 15:42:27.951329271 +0200
 +++ openssl-1.1.1c/Configurations/unix-Makefile.tmpl	2019-05-29 15:42:27.974328867 +0200
-@@ -180,6 +180,10 @@ MANDIR=$(INSTALLTOP)/share/man
+@@ -278,6 +278,10 @@ MANDIR=$(INSTALLTOP)/share/man
  DOCDIR=$(INSTALLTOP)/share/doc/$(BASENAME)
  HTMLDIR=$(DOCDIR)/html
  
@@ -12,7 +12,7 @@ diff -up openssl-1.1.1c/Configurations/unix-Makefile.tmpl.system-cipherlist open
  # MANSUFFIX is for the benefit of anyone who may want to have a suffix
  # appended after the manpage file section number.  "ssl" is popular,
  # resulting in files such as config.5ssl rather than config.5.
-@@ -203,6 +207,7 @@ CC=$(CROSS_COMPILE){- $config{CC} -}
+@@ -301,6 +305,7 @@ CC=$(CROSS_COMPILE){- $config{CC} -}
  CXX={- $config{CXX} ? "\$(CROSS_COMPILE)$config{CXX}" : '' -}
  CPPFLAGS={- our $cppflags1 = join(" ",
                                    (map { "-D".$_} @{$config{CPPDEFINES}}),
@@ -42,7 +42,7 @@ diff -up openssl-1.1.1c/Configure.system-cipherlist openssl-1.1.1c/Configure
  # --cross-compile-prefix Add specified prefix to binutils components.
  #
  # --api         One of 0.9.8, 1.0.0 or 1.1.0.  Do not compile support for
-@@ -295,6 +298,7 @@ $config{prefix}="";
+@@ -314,6 +317,7 @@ $config{prefix}="";
  $config{openssldir}="";
  $config{processor}="";
  $config{libdir}="";
@@ -50,7 +50,7 @@ diff -up openssl-1.1.1c/Configure.system-cipherlist openssl-1.1.1c/Configure
  my $auto_threads=1;    # enable threads automatically? true by default
  my $default_ranlib;
  
-@@ -824,6 +828,10 @@ while (@argvcopy)
+@@ -844,6 +848,10 @@ while (@argvcopy)
                              push @seed_sources, $x;
                              }
                          }
@@ -61,7 +61,7 @@ diff -up openssl-1.1.1c/Configure.system-cipherlist openssl-1.1.1c/Configure
                  elsif (/^--cross-compile-prefix=(.*)$/)
                          {
                          $user{CROSS_COMPILE}=$1;
-@@ -1016,6 +1024,8 @@ if ($target eq "HASH") {
+@@ -1052,6 +1060,8 @@ if ($target eq "HASH") {
      exit 0;
  }
  
@@ -116,7 +116,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
  #include <stdio.h>
  #include <ctype.h>
  #include <openssl/objects.h>
-@@ -1399,6 +1401,53 @@ int SSL_set_ciphersuites(SSL *s, const c
+@@ -1398,6 +1400,53 @@ int SSL_set_ciphersuites(SSL *s, const c
      return ret;
  }
  
@@ -170,7 +170,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
  STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *ssl_method,
                                               STACK_OF(SSL_CIPHER) *tls13_ciphersuites,
                                               STACK_OF(SSL_CIPHER) **cipher_list,
-@@ -1412,15 +1461,25 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1411,15 +1460,25 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      const char *rule_p;
      CIPHER_ORDER *co_list = NULL, *head = NULL, *tail = NULL, *curr;
      const SSL_CIPHER **ca_list = NULL;
@@ -198,7 +198,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
  #endif
  
      /*
-@@ -1443,7 +1502,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1442,7 +1501,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      co_list = OPENSSL_malloc(sizeof(*co_list) * num_of_ciphers);
      if (co_list == NULL) {
          SSLerr(SSL_F_SSL_CREATE_CIPHER_LIST, ERR_R_MALLOC_FAILURE);
@@ -207,7 +207,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
      }
  
      ssl_cipher_collect_ciphers(ssl_method, num_of_ciphers,
-@@ -1509,8 +1568,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1508,8 +1567,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * in force within each class
       */
      if (!ssl_cipher_strength_sort(&head, &tail)) {
@@ -217,7 +217,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
      }
  
      /*
-@@ -1555,9 +1613,8 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1554,9 +1612,8 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      num_of_alias_max = num_of_ciphers + num_of_group_aliases + 1;
      ca_list = OPENSSL_malloc(sizeof(*ca_list) * num_of_alias_max);
      if (ca_list == NULL) {
@@ -228,7 +228,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
      }
      ssl_cipher_collect_aliases(ca_list, num_of_group_aliases,
                                 disabled_mkey, disabled_auth, disabled_enc,
-@@ -1583,8 +1640,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1582,8 +1639,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      OPENSSL_free(ca_list);      /* Not needed anymore */
  
      if (!ok) {                  /* Rule processing failure */
@@ -238,7 +238,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
      }
  
      /*
-@@ -1592,10 +1648,13 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1591,10 +1647,13 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * if we cannot get one.
       */
      if ((cipherstack = sk_SSL_CIPHER_new_null()) == NULL) {
@@ -254,7 +254,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
      /* Add TLSv1.3 ciphers first - we always prefer those if possible */
      for (i = 0; i < sk_SSL_CIPHER_num(tls13_ciphersuites); i++) {
          if (!sk_SSL_CIPHER_push(cipherstack,
-@@ -1631,6 +1691,14 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1631,6 +1690,14 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      *cipher_list = cipherstack;
  
      return cipherstack;
@@ -272,7 +272,7 @@ diff -up openssl-1.1.1c/ssl/ssl_ciph.c.system-cipherlist openssl-1.1.1c/ssl/ssl_
 diff -up openssl-1.1.1c/ssl/ssl_lib.c.system-cipherlist openssl-1.1.1c/ssl/ssl_lib.c
 --- openssl-1.1.1c/ssl/ssl_lib.c.system-cipherlist	2019-05-29 15:42:27.970328937 +0200
 +++ openssl-1.1.1c/ssl/ssl_lib.c	2019-05-29 15:42:27.977328814 +0200
-@@ -662,7 +662,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx
+@@ -667,7 +667,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx
                                  ctx->tls13_ciphersuites,
                                  &(ctx->cipher_list),
                                  &(ctx->cipher_list_by_id),
@@ -281,7 +281,7 @@ diff -up openssl-1.1.1c/ssl/ssl_lib.c.system-cipherlist openssl-1.1.1c/ssl/ssl_l
      if ((sk == NULL) || (sk_SSL_CIPHER_num(sk) <= 0)) {
          SSLerr(SSL_F_SSL_CTX_SET_SSL_VERSION, SSL_R_SSL_LIBRARY_HAS_NO_CIPHERS);
          return 0;
-@@ -2954,7 +2954,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
+@@ -3086,7 +3086,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *m
      if (!ssl_create_cipher_list(ret->method,
                                  ret->tls13_ciphersuites,
                                  &ret->cipher_list, &ret->cipher_list_by_id,

--- a/rpm/openssl-1.1.1-version-override.patch
+++ b/rpm/openssl-1.1.1-version-override.patch
@@ -4,9 +4,9 @@ diff -up openssl-1.1.1q/include/openssl/opensslv.h.version-override openssl-1.1.
 @@ -40,7 +40,7 @@ extern "C" {
   *  major minor fix final patch/beta)
   */
- # define OPENSSL_VERSION_NUMBER  0x1010113fL
--# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1s  1 Nov 2022"
-+# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1s  FIPS 1 Nov 2022"
+ # define OPENSSL_VERSION_NUMBER  0x1010116fL
+-# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1v  1 Aug 2023"
++# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1v  FIPS 1 Aug 2023"
  
  /*-
   * The macros below are to be used for shared library (.so, .dll, ...)

--- a/rpm/openssl-1_1-Optimize-AES-XTS-aarch64.patch
+++ b/rpm/openssl-1_1-Optimize-AES-XTS-aarch64.patch
@@ -117,7 +117,7 @@ Index: openssl-1.1.1d/crypto/aes/asm/aesv8-armx.pl
 ===================================================================
 --- openssl-1.1.1d.orig/crypto/aes/asm/aesv8-armx.pl
 +++ openssl-1.1.1d/crypto/aes/asm/aesv8-armx.pl
-@@ -897,6 +897,1432 @@ $code.=<<___;
+@@ -1351,6 +1351,1432 @@ $code.=<<___;
  .size	${prefix}_ctr32_encrypt_blocks,.-${prefix}_ctr32_encrypt_blocks
  ___
  }}}

--- a/rpm/openssl-1_1-Optimize-RSA-armv8.patch
+++ b/rpm/openssl-1_1-Optimize-RSA-armv8.patch
@@ -120,7 +120,7 @@ Index: openssl-1.1.1d/crypto/armcap.c
  # endif
  uint32_t _armv7_tick(void);
  
-@@ -95,6 +98,7 @@ void OPENSSL_cpuid_setup(void) __attribu
+@@ -130,6 +133,7 @@ void OPENSSL_cpuid_setup(void) __attribu
  #  define HWCAP_CE_PMULL         (1 << 4)
  #  define HWCAP_CE_SHA1          (1 << 5)
  #  define HWCAP_CE_SHA256        (1 << 6)
@@ -128,7 +128,7 @@ Index: openssl-1.1.1d/crypto/armcap.c
  #  define HWCAP_CE_SHA512        (1 << 21)
  # endif
  
-@@ -155,6 +159,9 @@ void OPENSSL_cpuid_setup(void)
+@@ -190,6 +194,9 @@ void OPENSSL_cpuid_setup(void)
  #  ifdef __aarch64__
          if (hwcap & HWCAP_CE_SHA512)
              OPENSSL_armcap_P |= ARMV8_SHA512;
@@ -138,7 +138,7 @@ Index: openssl-1.1.1d/crypto/armcap.c
  #  endif
      }
  # endif
-@@ -210,5 +217,16 @@ void OPENSSL_cpuid_setup(void)
+@@ -245,5 +252,16 @@ void OPENSSL_cpuid_setup(void)
  
      sigaction(SIGILL, &ill_oact, NULL);
      sigprocmask(SIG_SETMASK, &oset, NULL);
@@ -568,7 +568,7 @@ Index: openssl-1.1.1d/crypto/bn/build.info
 ===================================================================
 --- openssl-1.1.1d.orig/crypto/bn/build.info
 +++ openssl-1.1.1d/crypto/bn/build.info
-@@ -65,3 +65,4 @@ INCLUDE[armv4-mont.o]=..
+@@ -64,3 +64,4 @@ INCLUDE[armv4-mont.o]=..
  GENERATE[armv4-gf2m.S]=asm/armv4-gf2m.pl $(PERLASM_SCHEME)
  INCLUDE[armv4-gf2m.o]=..
  GENERATE[armv8-mont.S]=asm/armv8-mont.pl $(PERLASM_SCHEME)

--- a/rpm/openssl.spec
+++ b/rpm/openssl.spec
@@ -26,7 +26,7 @@
 %define thread_test_threads %{?threads:%{threads}}%{!?threads:1}
 Summary: Utilities from the general purpose cryptography library with TLS implementation
 Name: openssl
-Version: 1.1.1s
+Version: 1.1.1v
 # Do not forget to bump SHLIB_VERSION on version upgrades
 Release: 1
 
@@ -80,9 +80,9 @@ Patch52: openssl-1.1.1-s390x-update.patch
 Patch53: openssl-1.1.1-fips-crng-test.patch
 Patch55: openssl-1.1.1-aes-asm-aesv8-armx.pl-20-improvement-on-ThunderX2.patch
 Patch56: openssl-1.1.1-s390x-ecc.patch
-Patch57: openssl-1_1-Optimize-AES-GCM-uarchs.patch
-Patch58: openssl-1_1-Optimize-AES-XTS-aarch64.patch
-Patch59: openssl-1_1-Optimize-RSA-armv8.patch
+Patch57: openssl-1_1-Optimize-RSA-armv8.patch
+Patch58: openssl-1_1-Optimize-AES-GCM-uarchs.patch
+Patch59: openssl-1_1-Optimize-AES-XTS-aarch64.patch
 
 License: OpenSSL
 URL: http://www.openssl.org/
@@ -183,6 +183,9 @@ cp %{SOURCE13} test/
 %patch53 -p1 -b .crng-test
 %patch55 -p1 -b .arm-update
 %patch56 -p1 -b .s390x-ecc
+%patch57 -p1 -b .opt-rsa
+%patch58 -p1 -b .opt-aes-gcm
+%patch59 -p1 -b .opt-aem-xts
 %patch60 -p1 -b .krb5-kdf
 %patch61 -p1 -b .edk2-build
 %patch62 -p1 -b .fips-curves


### PR DESCRIPTION
Actually use performance patches missed in previous update.

The following CVE's are addressed with this update:
- CVE-2022-4304
- CVE-2022-4450
- CVE-2023-0215
- CVE-2023-0286
- CVE-2023-0464
- CVE-2023-0465
- CVE-2023-0466
- CVE-2023-2650
- CVE-2023-3446
- CVE-2023-3817