### PR TITLE
[openssl] Drop make and perl dependencies from openssl package. JB#63112

### DIFF
--- a/rpm/openssl.spec
+++ b/rpm/openssl.spec
@@ -96,7 +96,7 @@ BuildRequires: diffutils
 BuildRequires: util-linux
 
 
-Requires: coreutils, make
+Requires: coreutils
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description
@@ -403,7 +403,6 @@ cp -a /%{_lib}/libcrypto.so.%{old_soversion} $RPM_BUILD_ROOT/%{_lib}/.
 
 %files
 %defattr(-,root,root)
-%attr(0755,root,root) %{_bindir}/c_rehash
 %{!?_licensedir:%global license %%doc}
 %license LICENSE
 %doc FAQ NEWS README README.FIPS


### PR DESCRIPTION
The makefile seemed there for SOURCE2 which we don't install and regarding that Fedora moved it around a bit and removed the make dependency with f20f5f466f6a in 2017.

c_rehash is now duplicate to the one in -perl subpackage and appears introduced by update to 1.1.1g by commit f8a4976b.